### PR TITLE
Add 'Hide when idle' setting and UI behavior

### DIFF
--- a/app/src/main/java/com/agupta07505/smartisland/data/SmartIslandSettings.kt
+++ b/app/src/main/java/com/agupta07505/smartisland/data/SmartIslandSettings.kt
@@ -32,7 +32,8 @@ data class SmartIslandSettings(
     val liveActivitiesEnabled: Boolean = true,
     val navigationEnabled: Boolean = true,
     val disabledNotificationPackages: Set<String> = emptySet(),
-    val disabledSoundPackages: Set<String> = emptySet()
+    val disabledSoundPackages: Set<String> = emptySet(),
+    val hideWhenIdle: Boolean = false
 ) {
     companion object {
         val Default = SmartIslandSettings()

--- a/app/src/main/java/com/agupta07505/smartisland/data/SmartIslandSettingsRepository.kt
+++ b/app/src/main/java/com/agupta07505/smartisland/data/SmartIslandSettingsRepository.kt
@@ -61,6 +61,7 @@ class SmartIslandSettingsRepository(private val context: Context) {
         val NavigationEnabled = booleanPreferencesKey("navigation_enabled")
         val DisabledNotificationPackages = stringSetPreferencesKey("disabled_notification_packages")
         val DisabledSoundPackages = stringSetPreferencesKey("disabled_sound_packages")
+        val HideWhenIdle = booleanPreferencesKey("hide_when_idle")
     }
 
     val settings: Flow<SmartIslandSettings> = context.smartIslandDataStore.data
@@ -149,7 +150,8 @@ class SmartIslandSettingsRepository(private val context: Context) {
                     ?.asSequence()
                     ?.filter { it.isNotBlank() && it.length <= MAX_PACKAGE_NAME_LENGTH }
                     ?.toSet()
-                    ?: defaults.disabledSoundPackages
+                    ?: defaults.disabledSoundPackages,
+                hideWhenIdle = prefs[Keys.HideWhenIdle] ?: defaults.hideWhenIdle
             )
         }
 
@@ -278,6 +280,9 @@ class SmartIslandSettingsRepository(private val context: Context) {
             .asSequence()
             .filter { pkg -> pkg.isNotBlank() && pkg.length <= MAX_PACKAGE_NAME_LENGTH }
             .toSet()
+    }
+    suspend fun setHideWhenIdle(value: Boolean) = editSafely {
+        it[Keys.HideWhenIdle] = value
     }
 
     suspend fun resetPosition() = editSafely {

--- a/app/src/main/java/com/agupta07505/smartisland/service/SmartIslandOverlayService.kt
+++ b/app/src/main/java/com/agupta07505/smartisland/service/SmartIslandOverlayService.kt
@@ -235,6 +235,17 @@ class SmartIslandOverlayService : AccessibilityService() {
                 }
             }
         }
+
+        serviceScope.launch {
+            runSuspendCatchingLogged(TAG, "Notifications-state collector failed") {
+                viewModel.notifications.collectLatest {
+                    if (destroyed || !viewModel.settings.value.enabled) {
+                        return@collectLatest
+                    }
+                    updateWindowLayoutParams(viewModel.expanded.value, viewModel.settings.value)
+                }
+            }
+        }
     }
 
     override fun onServiceConnected() {

--- a/app/src/main/java/com/agupta07505/smartisland/ui/IslandOverlayView.kt
+++ b/app/src/main/java/com/agupta07505/smartisland/ui/IslandOverlayView.kt
@@ -28,9 +28,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -111,23 +113,22 @@ fun IslandOverlayView(
     // Keyed on `expanded` so it resets to collapsed height on every expand/collapse
     // cycle, avoiding stale measurements from a previous expansion.
     var expandedHeight by remember(expanded) {
-        mutableStateOf(settings.height.dp)
+        mutableStateOf(if (notifications.isEmpty()) 135.dp else settings.height.dp)
     }
 
+    val isIdleHiding = settings.hideWhenIdle && notifications.isEmpty()
+
     val width by transition.animateDp(transitionSpec = { sizeSpec }, label = "islandWidth") {
-        if (it) expandedWidth else settings.width.dp
+        if (it) expandedWidth else if (isIdleHiding) 0.dp else settings.width.dp
     }
     val height by transition.animateDp(transitionSpec = { heightSpec }, label = "islandHeight") {
-        // FIX: No more 160.dp hardcoded fallback. expandedHeight is always non-null now.
-        // It starts at collapsed height and gets updated to the real content height
-        // within 1-2 frames. The spring animation smoothly follows.
-        if (it) expandedHeight else settings.height.dp
+        if (it) expandedHeight else if (isIdleHiding) 0.dp else settings.height.dp
     }
     val yOffset by transition.animateDp(transitionSpec = { sizeSpec }, label = "islandYOffset") {
         if (it) statusBarHeight.dp else 0.dp
     }
     val radius by transition.animateDp(transitionSpec = { sizeSpec }, label = "islandRadius") {
-        if (it) 34.dp else settings.cornerRadius.dp
+        if (it) 34.dp else if (isIdleHiding) 0.dp else settings.cornerRadius.dp
     }
     val animatedXOffset by transition.animateDp(transitionSpec = { sizeSpec }, label = "islandXOffset") {
         if (it) 0.dp else settings.xOffset.dp
@@ -137,7 +138,7 @@ fun IslandOverlayView(
         transitionSpec = { alphaSpec },
         label = "collapsedAlpha"
     ) {
-        if (it) 0f else 1f
+        if (it || isIdleHiding) 0f else 1f
     }
 
     val expandedAlpha by transition.animateFloat(
@@ -160,6 +161,10 @@ fun IslandOverlayView(
     ) {
         if (it) 0.dp else (-12).dp
     }
+
+    val safeWidth = width.coerceAtLeast(0.dp)
+    val safeHeight = height.coerceAtLeast(0.dp)
+    val safeRadius = radius.coerceAtLeast(0.dp)
 
     val activeNotification = notifications.getOrNull(selectedIndex)
     val activeMode = activeNotification?.mode ?: IslandMode.Empty
@@ -185,8 +190,8 @@ fun IslandOverlayView(
         if (notifications.size > 1 && collapsedAlpha > 0f) {
             Canvas(
                 modifier = Modifier
-                    .width(width)
-                    .height(height)
+                    .width(safeWidth)
+                    .height(safeHeight)
                     .graphicsLayer {
                         val currentWidth = size.width
                         val desiredCenterX = screenCenterPx + animatedXOffset.toPx()
@@ -197,7 +202,7 @@ fun IslandOverlayView(
             ) {
                 val h = size.height
                 val w = size.width
-                val r = radius.toPx().coerceAtMost(h / 2f)
+                val r = safeRadius.toPx().coerceAtLeast(0f).coerceAtMost(h / 2f)
                 val gap = STACK_INDICATOR_GAP_DP.dp.toPx()
                 val strokeW = STACK_INDICATOR_STROKE_DP.dp.toPx()
                 val rArc = r + gap
@@ -226,18 +231,38 @@ fun IslandOverlayView(
             }
         }
 
+        // Invisible touch target over the pill location when idle-hiding, so tapping the camera cutout opens shortcuts
+        if (isIdleHiding && !currentExpanded) {
+            Box(
+                modifier = Modifier
+                    .width(settings.width.dp)
+                    .height(settings.height.dp)
+                    .graphicsLayer {
+                        val currentWidth = size.width
+                        val desiredCenterX = screenCenterPx + (settings.xOffset * displayMetrics.density)
+                        translationX = desiredCenterX - (currentWidth / 2f)
+                        translationY = settings.yOffset * displayMetrics.density
+                    }
+                    .pointerInput(Unit) {
+                        detectTapGestures {
+                            currentOnToggle()
+                        }
+                    }
+            )
+        }
+
         // Inner Box: The actual visible pill container, managing the black background shape and size animations
         Box(
             modifier = Modifier
-                .width(width)
-                .height(height)
+                .width(safeWidth)
+                .height(safeHeight)
                 .graphicsLayer {
                     val currentWidth = size.width
                     val desiredCenterX = screenCenterPx + animatedXOffset.toPx()
                     translationX = desiredCenterX - (currentWidth / 2f)
                     translationY = yOffset.toPx() + dragOffset
                 }
-                .clip(RoundedCornerShape(radius))
+                .clip(RoundedCornerShape(safeRadius))
                 .background(Color.Black)
                 .pointerInput(Unit) {
                     detectTapGestures {
@@ -329,7 +354,8 @@ fun IslandOverlayView(
             if (expanded) {
                 Box(
                     modifier = Modifier
-                        .fillMaxSize()
+                        .fillMaxWidth()
+                        .wrapContentHeight()
                         .graphicsLayer {
                             alpha = expandedAlpha
                             scaleX = contentScale

--- a/app/src/main/java/com/agupta07505/smartisland/ui/expanded/IslandExpandedContent.kt
+++ b/app/src/main/java/com/agupta07505/smartisland/ui/expanded/IslandExpandedContent.kt
@@ -66,12 +66,13 @@ fun IslandExpandedContent(
         Box(
             modifier = modifier
                 .fillMaxWidth()
-                // The island starts at collapsed height. Unbounded measurement is
-                // required here so the launcher can discover its natural height.
-                .wrapContentHeight(unbounded = true)
+                .wrapContentHeight()
                 .onSizeChanged {
                     val measuredHeight = with(density) { it.height.toDp() }
-                    if (measuredHeight > 0.dp) onHeightMeasured(measuredHeight)
+                    if (measuredHeight > 0.dp) {
+                        val clamped = measuredHeight.coerceIn(80.dp, 180.dp)
+                        onHeightMeasured(clamped)
+                    }
                 }
         ) {
             EmptyExpanded(settings = settings, apps = launcherApps, onLaunchApp = onLaunchApp)

--- a/app/src/main/java/com/agupta07505/smartisland/ui/sections/NotificationsAndPrivacySection.kt
+++ b/app/src/main/java/com/agupta07505/smartisland/ui/sections/NotificationsAndPrivacySection.kt
@@ -265,6 +265,50 @@ fun NotificationsAndPrivacySection(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
+                    text = "Hide Pill when idle",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "Automatically hide the Smart Island pill when there are no active notifications or dynamic events.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    lineHeight = 16.sp
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Switch(
+                checked = settings.hideWhenIdle,
+                onCheckedChange = { checked ->
+                    scope.launch { repository.setHideWhenIdle(checked) }
+                }
+            )
+        }
+    }
+
+    Spacer(Modifier.height(16.dp))
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
                     text = "Live Activities",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,


### PR DESCRIPTION
Introduce a new hideWhenIdle setting (default=false) and persist it in the DataStore with a setter. Service now listens to notification state changes and updates window layout. Overlay UI respects hideWhenIdle by collapsing width/height/radius to 0 when idle, adds an invisible touch target to open shortcuts, and uses safe dimension values to avoid negative sizes. Expanded content measurement is clamped (80–180dp) and no longer uses unbounded measurement. Settings screen gains a card with a Switch to toggle the new behavior. Files updated: SmartIslandSettings, SmartIslandSettingsRepository, SmartIslandOverlayService, IslandOverlayView, IslandExpandedContent, NotificationsAndPrivacySection.

## Description

<!-- Briefly describe what this PR changes and why. -->

## Related Issue

<!-- Use "Closes #123" or "Fixes #123" when applicable. -->

## Type Of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Build/release change

## App Area

- [ ] Floating overlay island
- [ ] Notification listener
- [ ] Incoming calls
- [ ] Media playback
- [ ] Island settings/customization
- [ ] Permissions/onboarding
- [ ] Privacy/security
- [ ] CI/CD or Gradle
- [ ] Documentation

## Screenshots Or Recordings

<!-- Required for visible UI changes. Add before/after media when possible. Remove private notification content. -->

| Before | After |
|--------|-------|
|        |       |

## Testing

<!-- List commands, devices, emulators, and manual checks performed. -->

- [ ] `./gradlew assembleDebug`
- [ ] `./gradlew assembleRelease`
- [ ] Overlay permission flow tested, if affected
- [ ] Notification listener flow tested, if affected
- [ ] Incoming call or media notification flow tested, if affected
- [ ] Manual device/emulator testing

## Checklist

- [ ] My code follows the existing project style.
- [ ] I kept the change focused.
- [ ] I added or updated tests where useful.
- [ ] I updated docs/templates when behavior changed.
- [ ] I did not commit secrets, keystores, generated APKs, `_base64.txt` files, or local paths.
- [ ] Screenshots and logs do not contain private notification content.
